### PR TITLE
Update blake3 to 1.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: ci-data
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
         ruby: ${{ fromJSON(needs.ci-data.outputs.result).stable-ruby-versions }}
@@ -33,6 +34,7 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
+          rustup-toolchain: "1.78"
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           cargo-cache: true
@@ -41,7 +43,7 @@ jobs:
       - uses: "oxidize-rb/actions/cargo-binstall@v1"
         with:
           crate: "b3sum"
-          version: "1.5.0"
+          version: "1.5.1"
 
       - name: Compile
         run: bundle exec rake compile
@@ -56,8 +58,8 @@ jobs:
 
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
-          rustup-toolchain: "1.73"
-          ruby-version: "3.2"
+          rustup-toolchain: "1.78"
+          ruby-version: "3.3"
           bundler-cache: true
           cargo-cache: true
           cache-version: v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -45,15 +45,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blake3"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -67,17 +67,18 @@ name = "blake3_ext"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "hex",
+ "rand",
  "rb-sys",
+ "rb-sys-env",
+ "rb-sys-test-helpers",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cexpr"
@@ -113,15 +114,32 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "itertools"
@@ -146,25 +164,25 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libloading"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-targets",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "minimal-lexical"
@@ -183,37 +201,73 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.78"
+name = "ppv-lite86"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rb-sys"
-version = "0.9.88"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11b0965e6df9ef800ac71efc46070960a119f92af1b64d6acd4c357dc139350"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rb-sys"
+version = "0.9.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d30bcad206b51f2f66121190ca678dce1fdf3a2eae0ac5d838d1818b19bdf5"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.88"
+version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0fce6e53552df8fcd3e4269d7944b0afa38db70d252bbf12caad454caf6d83"
+checksum = "3cbd92f281615f3c2dcb9dcb0f0576624752afbf9a7f99173b37c4b55b62dd8a"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -225,10 +279,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.3"
+name = "rb-sys-env"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
+
+[[package]]
+name = "rb-sys-test-helpers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd592029353df7955a76ca0b1bf0d9ccc57feab96615f80d1fe756462864949"
+dependencies = [
+ "rb-sys",
+ "rb-sys-env",
+ "rb-sys-test-helpers-macros",
+]
+
+[[package]]
+name = "rb-sys-test-helpers-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c21f156459adb755d58f73dbd783dc1de8b403635e637f7d1daec1c7a920c1f5"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -238,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -249,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rustc-hash"
@@ -273,9 +354,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -289,23 +370,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -314,42 +393,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ resolver = "2"
 lto = true
 opt-level = 3
 codegen-units = 1
+debug = true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    blake3-rb (1.5.4)
+    blake3-rb (1.5.4.1)
       rb_sys (~> 0.9)
 
 GEM
@@ -24,7 +24,7 @@ GEM
     rake (13.1.0)
     rake-compiler (1.2.7)
       rake
-    rb_sys (0.9.88)
+    rb_sys (0.9.97)
     regexp_parser (2.9.0)
     rexml (3.2.6)
     rubocop (1.60.2)

--- a/blake3-rb.gemspec
+++ b/blake3-rb.gemspec
@@ -2,7 +2,9 @@
 
 Gem::Specification.new do |spec|
   spec.name = "blake3-rb"
-  spec.version = "1.5.4"
+  # Eventually, we would like to align with the upstream blake3 crate version,
+  # so only ship patch-level changes in the gem version.
+  spec.version = "1.5.4.1"
   spec.authors = ["Ian Ker-Seymer"]
 
   spec.summary = "Blake3 hash function bindings for Ruby."

--- a/ext/digest/blake3_ext/Cargo.toml
+++ b/ext/digest/blake3_ext/Cargo.toml
@@ -10,5 +10,13 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-rb-sys = { version = "0.9.88", features = ["stable-api-compiled-fallback"] }
-blake3 = { version = "1.5.0" }
+rb-sys = { version = "0.9", features = ["stable-api-compiled-fallback"] }
+blake3 = { version = "1.5" }
+
+[dev-dependencies]
+hex = "0.4.3"
+rand = "0.8.5"
+rb-sys-test-helpers = "0.2.0"
+
+[build-dependencies]
+rb-sys-env = "0.1.2"

--- a/ext/digest/blake3_ext/build.rs
+++ b/ext/digest/blake3_ext/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    rb_sys_env::activate()?;
+    Ok(())
+}

--- a/ext/digest/blake3_ext/src/lib.rs
+++ b/ext/digest/blake3_ext/src/lib.rs
@@ -5,57 +5,61 @@ use rb_sys::{
     rb_cObject, rb_const_get, rb_define_class_under, rb_intern, rb_ivar_set, rb_require, size_t,
 };
 use std::ffi::{c_int, c_uchar, c_void};
+use std::mem::MaybeUninit;
 use std::os::raw::c_char;
 
 use bindings::{rb_digest_make_metadata, RbDigestMetadataT, RUBY_DIGEST_API_VERSION};
 
-const BLOCK_LEN: usize = 64;
-const DIGEST_LEN: usize = 32;
-
 #[repr(C)]
-#[derive(Debug)]
-struct Blake3Ctx {
-    inner: Option<Hasher>,
+#[derive(Debug, Default)]
+struct Blake3 {
+    hasher: Hasher,
 }
 
-static DIGEST_METADATA: RbDigestMetadataT = RbDigestMetadataT {
-    api_version: RUBY_DIGEST_API_VERSION,
-    digest_len: DIGEST_LEN as _,
-    block_len: BLOCK_LEN as _,
-    ctx_size: std::mem::size_of::<Blake3Ctx>() as _,
-    init_func: blake3_init,
-    update_func: blake3_update,
-    finish_func: blake3_finish,
-};
+impl Blake3 {
+    const BLOCK_LEN: usize = 64;
+    const DIGEST_LEN: usize = 32;
 
-// Initialize the context, which has already been allocated by Ruby.
-extern "C" fn blake3_init(ctx: *mut c_void) -> c_int {
-    let ctx = ctx as *mut Blake3Ctx;
-    let ctx = unsafe { &mut *ctx };
-    ctx.inner = Some(Hasher::new());
-    1
-}
-
-// Update the context with the given data.
-extern "C" fn blake3_update(ctx: *mut c_void, data: *mut c_uchar, len: size_t) {
-    let ctx = ctx as *mut Blake3Ctx;
-    let ctx = unsafe { &mut *ctx };
-    if let Some(inner) = ctx.inner.as_mut() {
-        let slice = unsafe { std::slice::from_raw_parts(data, len as _) };
-        inner.update(slice);
+    fn digest_metadata() -> &'static RbDigestMetadataT {
+        static DIGEST_METADATA: RbDigestMetadataT = RbDigestMetadataT {
+            api_version: RUBY_DIGEST_API_VERSION,
+            digest_len: Blake3::DIGEST_LEN as _,
+            block_len: Blake3::BLOCK_LEN as _,
+            ctx_size: std::mem::size_of::<Blake3>() as _,
+            init_func: Blake3::init_in_place,
+            update_func: Blake3::update,
+            finish_func: Blake3::finish,
+        };
+        &DIGEST_METADATA
     }
-}
 
-// Finalize the context and write the digest to the given pointer.
-extern "C" fn blake3_finish(ctx: *mut c_void, digest: *mut c_uchar) -> c_int {
-    let ctx = ctx as *mut Blake3Ctx;
-    let ctx = unsafe { &mut *ctx };
-    if let Some(inner) = ctx.inner.as_mut() {
-        let slice = unsafe { std::slice::from_raw_parts_mut(digest, DIGEST_LEN) };
-        inner.finalize_xof().fill(slice);
-        1
-    } else {
-        0
+    // Initialize the context, which has already been allocated by Ruby.
+    extern "C" fn init_in_place(ctx: *mut c_void) -> c_int {
+        let ctx = ctx as *mut MaybeUninit<Blake3>;
+        let ctx = unsafe { &mut *ctx };
+        ctx.write(Blake3::default());
+        true as _
+    }
+
+    // Update the context with the given data.
+    extern "C" fn update(ctx: *mut c_void, data: *mut c_uchar, len: size_t) {
+        let ctx = ctx as *mut MaybeUninit<Blake3>;
+        let ctx = unsafe { &mut *ctx };
+        let ctx = unsafe { ctx.assume_init_mut() };
+        let slice = unsafe { std::slice::from_raw_parts(data, len as _) };
+
+        ctx.hasher.update(slice);
+    }
+
+    // Finalize the context and write the digest to the given pointer. The
+    // memory for the digest is managed by Ruby, so we don't need to free it.
+    extern "C" fn finish(ctx: *mut c_void, digest: *mut c_uchar) -> c_int {
+        let ctx = ctx as *mut MaybeUninit<Blake3>;
+        let ctx = unsafe { &mut *ctx };
+        let ctx = unsafe { ctx.assume_init_mut() };
+        let outbuf = unsafe { std::slice::from_raw_parts_mut(digest, Self::DIGEST_LEN) };
+        ctx.hasher.finalize_xof().fill(outbuf);
+        true as _
     }
 }
 
@@ -71,7 +75,101 @@ pub unsafe extern "C" fn Init_blake3_ext() {
         "Blake3\0".as_ptr() as *const c_char,
         digest_base,
     );
-    let meta = rb_digest_make_metadata(&DIGEST_METADATA);
+    let meta = rb_digest_make_metadata(Blake3::digest_metadata());
     let metadata_id = rb_intern("metadata\0".as_ptr() as *const c_char);
     rb_ivar_set(klass, metadata_id, meta);
+}
+
+#[cfg(test)]
+mod tests {
+    use rb_sys::{
+        rb_cObject, rb_const_get, rb_enc_set_index, rb_funcallv_public, rb_intern, rb_str_new,
+        rb_utf8_encindex, RSTRING_LEN, RSTRING_PTR,
+    };
+    use rb_sys_test_helpers::{protect, ruby_test};
+
+    use crate::Init_blake3_ext;
+
+    #[ruby_test]
+    fn fuzz_parity_binary() {
+        setup();
+
+        for _ in 0..1024 {
+            let input_data = gen_random_bytes(4096);
+            let expected = compute_rust_digest(input_data.as_slice());
+            let actual = compute_ruby_digest(input_data.as_slice(), rb_utf8_encindex);
+
+            assert_eq!(expected, actual);
+        }
+    }
+
+    #[ruby_test]
+    fn fuzz_parity_utf8() {
+        setup();
+
+        for _ in 0..1024 {
+            let input_data = gen_random_string(512);
+            let expected = compute_rust_digest(&input_data);
+            let actual = compute_ruby_digest(&input_data, rb_utf8_encindex);
+
+            assert_eq!(expected, actual);
+        }
+    }
+
+    fn setup() {
+        static INIT: std::sync::Once = std::sync::Once::new();
+        INIT.call_once(|| {
+            protect(|| unsafe { Init_blake3_ext() })
+                .expect("Failed to initialize Blake3 extension");
+        });
+    }
+
+    fn gen_random_bytes(max_len: usize) -> Vec<u8> {
+        let size = rand::random::<usize>() % max_len;
+        (0..size).map(|_| rand::random::<u8>()).collect()
+    }
+
+    fn gen_random_string(max_len: usize) -> String {
+        let size = rand::random::<usize>() % max_len;
+        (0..size)
+            .map(|_| rand::random::<char>())
+            .collect::<String>()
+    }
+
+    fn compute_rust_digest<T: AsRef<[u8]>>(input: T) -> String {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(input.as_ref());
+        let mut result = [0u8; 32];
+        hasher.finalize_xof().fill(&mut result);
+        hex::encode(result)
+    }
+
+    fn compute_ruby_digest<T: AsRef<[u8]>>(
+        input: T,
+        encoding: unsafe extern "C" fn() -> i32,
+    ) -> String {
+        let input = input.as_ref();
+        let ruby_digest = protect(|| unsafe {
+            Init_blake3_ext();
+            let klass = rb_const_get(rb_cObject, rb_intern("Digest\0".as_ptr() as _));
+            let klass = rb_const_get(klass, rb_intern("Blake3\0".as_ptr() as _));
+            let string = rb_str_new(input.as_ptr() as _, input.len() as _);
+            rb_enc_set_index(string, encoding());
+            let mut args = [string];
+            rb_funcallv_public(
+                klass,
+                rb_intern("hexdigest\0".as_ptr() as _),
+                args.len() as _,
+                args.as_mut_ptr(),
+            )
+        })
+        .unwrap();
+
+        let rstring_ptr = unsafe { RSTRING_PTR(ruby_digest) };
+        let rstring_len = unsafe { RSTRING_LEN(ruby_digest) };
+
+        let bytes =
+            unsafe { std::slice::from_raw_parts(rstring_ptr as *const u8, rstring_len as _) };
+        std::str::from_utf8(bytes).unwrap().to_string()
+    }
 }

--- a/test/b3sum_parity_test.rb
+++ b/test/b3sum_parity_test.rb
@@ -3,7 +3,11 @@
 require "test_helper"
 
 class B3SumParityTest < Minitest::Test
-  %x(git ls-files).split("\n").sort.each_with_index do |file, i|
+  files = %x(git ls-files).split("\n").sort
+
+  raise "No files found" if files.empty?
+
+  files.each_with_index do |file, i|
     next unless File.exist?(file)
 
     slug = file.gsub(/[^a-z0-9]/i, "_").downcase


### PR DESCRIPTION
This PR upgrades us to 1.5.1 upstream. I also took the time to clean up the code and add some tests.