### PR TITLE
Use public macro to decide whether to use rb_ext_resolve_symbol()

### DIFF
--- a/ext/digest/blake3_ext/extconf.rb
+++ b/ext/digest/blake3_ext/extconf.rb
@@ -3,4 +3,23 @@
 require "mkmf"
 require "rb_sys/mkmf"
 
-create_rust_makefile("digest/blake3/blake3_ext")
+# Detect when DIGEST_USE_RB_EXT_RESOLVE_SYMBOL is defined truthy,
+# which indicates rb_ext_resolve_symbol("digest.so", "rb_digest_wrap_metadata")
+# will work with the version of Digest we're building against.
+digest_use_rb_ext_resolve_symbol = try_compile(<<~C)
+  #include <ruby/digest.h>
+
+  #if !defined(DIGEST_USE_RB_EXT_RESOLVE_SYMBOL)
+  # error DIGEST_USE_RB_EXT_RESOLVE_SYMBOL not defined
+  #endif
+  #if !DIGEST_USE_RB_EXT_RESOLVE_SYMBOL
+  # error DIGEST_USE_RB_EXT_RESOLVE_SYMBOL is 0
+  #endif
+C
+puts("digest_use_rb_ext_resolve_symbol=#{digest_use_rb_ext_resolve_symbol}")
+
+create_rust_makefile("digest/blake3/blake3_ext") do |r|
+  if digest_use_rb_ext_resolve_symbol
+    r.extra_rustflags = ["--cfg digest_use_rb_ext_resolve_symbol"]
+  end
+end

--- a/ext/digest/blake3_ext/src/bindings.rs
+++ b/ext/digest/blake3_ext/src/bindings.rs
@@ -19,7 +19,7 @@ pub struct RbDigestMetadataT {
     pub finish_func: RbDigestHashFinishFuncT,
 }
 
-#[cfg(ruby_gt_3_3)]
+#[cfg(digest_use_rb_ext_resolve_symbol)]
 pub unsafe fn rb_digest_make_metadata(meta: &'static RbDigestMetadataT) -> VALUE {
     static mut WRAPPER: Option<unsafe extern "C" fn(&'static RbDigestMetadataT) -> VALUE> = None;
 
@@ -50,7 +50,7 @@ pub unsafe fn rb_digest_make_metadata(meta: &'static RbDigestMetadataT) -> VALUE
     panic!("Failed to resolve rb_digest_wrap_metadata");
 }
 
-#[cfg(not(ruby_gt_3_3))]
+#[cfg(not(digest_use_rb_ext_resolve_symbol))]
 pub unsafe fn rb_digest_make_metadata(meta: &'static RbDigestMetadataT) -> VALUE {
     use rb_sys::{rb_data_object_wrap, rb_obj_freeze};
     let data = rb_data_object_wrap(


### PR DESCRIPTION
Follow-up for #12. Version detection missed some range of development
versions that are 3.4.0dev, but ship a `Digest` that doesn't
export rb_digest_wrap_metadata(). For example,
https://github.com/Shopify/ruby-definitions/blob/main/rubies/3.4.0-pshopify-preview2

Ideally, we would call rb_digest_make_metadata() that Digest ships
directly instead of reimplementing it, but we already impose an
incredible amount of build burden on from-source consumers.
